### PR TITLE
Create Dockerfile for Kronos

### DIFF
--- a/kronos/docker/Dockerfile.template
+++ b/kronos/docker/Dockerfile.template
@@ -1,0 +1,14 @@
+FROM ubuntu:14.04
+
+RUN \
+  apt-get update && \
+  apt-get install -y git python2.7 build-essential wget supervisor
+RUN git clone https://github.com/Locu/chronology.git chronology
+WORKDIR chronology/kronos
+RUN git checkout __TAG__
+RUN make installdeps
+RUN python setup.py install
+RUN mkdir -p /home/kronos
+RUN chown -R kronos:kronos /home/kronos
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+CMD ["/usr/bin/supervisord"]

--- a/kronos/docker/Makefile
+++ b/kronos/docker/Makefile
@@ -1,0 +1,22 @@
+SHELL := /bin/bash
+
+ifndef KRONOS_VERSION
+$(error Please specify a KRONOS_VERSION, like `KRONOS_VERSION=v0.7.0 make build`)
+endif
+
+generate_dockerfile:
+	mkdir -p $(KRONOS_VERSION)
+	sed -e "s/__TAG__/$(KRONOS_VERSION)/" Dockerfile.template > $(KRONOS_VERSION)/Dockerfile
+	cp supervisord.conf $(KRONOS_VERSION)
+build:
+	cd $(KRONOS_VERSION) && sudo docker build -t chronology/kronos:$(KRONOS_VERSION) .
+build_nocache:
+	cd $(KRONOS_VERSION) && sudo docker build --no-cache -t chronology/kronos:$(KRONOS_VERSION) .
+run:
+	sudo docker run -d -p 8150:8150 -v /etc/kronos:/etc/kronos -v /var/log/kronos:/var/log/kronos chronology/kronos:$(KRONOS_VERSION)
+run-terminal:
+	sudo docker run -t -i chronology/kronos:$(KRONOS_VERSION) /bin/bash
+push:
+	sudo docker push chronology/kronos:$(KRONOS_VERSION)
+ip:
+	boot2docker ip

--- a/kronos/docker/README.md
+++ b/kronos/docker/README.md
@@ -1,0 +1,16 @@
+#Deploying with Docker
+
+## Quick usage HOWTO
+
+We've already pushed a working [Dockerfile to Docker Hub](https://registry.hub.docker.com/u/chronology/kronos/), so you can do something like the following:
+
+  * Put a `settings.py` in `/etc/kronos/settings.py`
+  * Create `/var/log/kronos` for log output
+  * Run `sudo docker run -d -p 8150:8150 -v /etc/kronos:/etc/kronos -v /var/log/kronos:/var/log/kronos chronology/kronos:$(KRONOS_VERSION)`
+
+## How to create new Dockerfiles for future versions of Kronos
+
+  * Tag the git commit for which you want to generate a Docker.
+  * In `kronos/docker` directory, run `KRONOS_VERSION=v0.7.0 make generate_dockerfile`
+  * In the same directory, run `KRONOS_VERSION=v0.7.0 make build`. Note: Docker aggressively caches commands for performance.  To avoid this, for example if you had to change which hash a tag points to, call `KRONOS_VERSION=v0.7.0 make build_nocache`.
+  * In the same directory, run `KRONOS_VERSION=v0.7.0 make push`

--- a/kronos/docker/supervisord.conf
+++ b/kronos/docker/supervisord.conf
@@ -1,0 +1,5 @@
+[supervisord]
+nodaemon=true
+
+[program:kronos]
+command=sudo service kronosd start

--- a/kronos/kronos/conf/logging.py
+++ b/kronos/kronos/conf/logging.py
@@ -28,6 +28,7 @@ def configure():
 
   logging.root.addHandler(error_handler)
   logging.root.addHandler(app_handler)
+  logging.root.setLevel(logging.NOTSET)
 
   # XXX: elasticsearch-py is annoying. They turn propagate=False for the
   # following logger so we keep on seeing 'No handlers could be found for logger

--- a/kronos/scripts/install_kronosd.py
+++ b/kronos/scripts/install_kronosd.py
@@ -56,10 +56,11 @@ def make_dirs():
 
 def copy_files():
   print 'Copying configuration and init.d script files...'
+  safe_mkdir('/etc/uwsgi')
   shutil.copy(os.path.join(BASE_DIR, 'scripts/uwsgi.ini'),
-              '/etc/kronos/uwsgi.ini')
-  shutil.copy(os.path.join(BASE_DIR, 'scripts/kronosd.init.d'),
-              '/etc/init.d/kronos')
+              '/etc/uwsgi/kronos.ini')
+  kronosd_file_path = os.path.join(BASE_DIR, 'scripts/kronosd.init.d')
+  shutil.copy(kronosd_file_path, '/etc/init.d/kronosd')
   with open(os.path.join(BASE_DIR, 'settings.py.template')) as f:
     settings = f.read()
   if not LOG_DIR_RE.search(settings):

--- a/kronos/scripts/kronosd.init.d
+++ b/kronos/scripts/kronosd.init.d
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 ### BEGIN INIT INFO
-# Provides:	kronosd
+# Provides: kronosd
 # Description: Kronos time series storage engine
 ### END INIT INFO
 
@@ -28,7 +28,7 @@ case "$1" in
   fi
 
 	echo -n "Starting kronosd: "
-	if (cd $LIBDIR/uwsgi && ./uwsgi --ini /etc/kronos/uwsgi.ini --pidfile $PIDFILE --daemonize $LOGFILE)
+	if (cd $LIBDIR/uwsgi && ./uwsgi --ini /etc/uwsgi/kronos.ini --pidfile $PIDFILE --daemonize $LOGFILE)
 	then
 		echo "ok"
 	else


### PR DESCRIPTION
Docker has 3 kronos services, one for all, one for readonly, one for collector. When docker is run, all three are started. Three ports are mapped. The log directory is mapped to `/var/log/kronos`. Settings file at `/etc/kronos/settings.py` is mapped into the docker.