### PR TITLE
Add Jia+Metis uwsgi support

### DIFF
--- a/jia/jia_uwsgi.py
+++ b/jia/jia_uwsgi.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+from jia import config
+
+app = config(settings_file='/etc/jia/settings.py')

--- a/metis/metis_uwsgi.py
+++ b/metis/metis_uwsgi.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+from metis import app
+
+app.config.from_pyfile('/etc/metis/settings.py')


### PR DESCRIPTION
These files are needed to provide a callable `app` for Jia and Metis.  After we land this commit, we can create a tag to Dockerify Jia+Metis on these two files with nginx+uwsgi.