### PR TITLE
Tune Kronos uwsgi performance while maintaining correctness

### DIFF
--- a/kronos/scripts/uwsgi.ini
+++ b/kronos/scripts/uwsgi.ini
@@ -8,18 +8,23 @@ module=kronos.app
 # when run with multiple interpreters.
 single-interpreter=True
 
-# 100 `async` cores for gevent. I think it means a 100 greenlets per process.
-gevent=100
-# Run 2 x `num_cpus` processes.
-num_cpus=%k
-processes=%(2 * num_cpus)
+# 30 `async` cores for gevent. I think it means 30 greenlets per process.
+gevent=30
+# Note: Running more than one process results in data loss at high
+# throughputs.  We're not sure why, but the current configuration
+# seems to handle high throughput (~350 events inserted/sec) without
+# losing data.  If you want higher parallelism, run multiple uWSGI
+# instances on the same machine (this was tested, and does not lose
+# data).
+processes=1
 
 # Run one master process.
 master=1
 
-# Reload if virtual address usage > 512mb or after 1000 requests.
+# Reload if virtual address usage or actual memory usage > 512
+# megabytes.
 reload-on-as=512
-max-requests=1000
+reload-on-rss=512
 
 # UID/GID.
 uid=kronos


### PR DESCRIPTION
While investigating weird uwsgi restarts in production, I load-tested our current configuration and noticed that it can result in data loss at high throughputs.  This script (note the command line args in the comment of the gist) is the performance test:

https://gist.github.com/marcua/873ab29142264fe3f8ef

I also have a followon test where I run multiple docker/uwsgi instances on different ports and load-balance between them.  In both cases, we result in no data loss with the following uwsgi config.

To recreate the docker setup, the following command suffices for testing the uwsgi settings:

`docker run -p 8167:8150 -v /etc/kronos-perftest:/etc/kronos -v /etc/kronos-perftest:/etc/uwsgi -v /var/log/kronos-collector:/var/log/kronos chronology/kronos:v0.7.2`
  * Make sure `/etc/kronos-perftest` contains both a `kronos.ini` for uwsgi as well as a Kronos `settings.py`.

Notes:
* It appears that running multiple uwsgi processes can result in data loss for us.
* It appears that max-requests doesn't gracefully restart processes, also resulting in data loss.
* I added `reload-on-as` and `reload-on-rss`, but noticed no change in either virtual or actual memory usage across several hundreds of thousands of inserts.
* We can get something like 350 inserts/second in this test.  You can likely eke more parallelism out of the system by running two uwsgi instances side-by-side behind nginx.
* The test script has a weird behavior where it will randomly pause inserting for a few seconds at a time.  Maybe some sort of kernel scheduling issue, or a python GC thing.  Not sure, but since that counts against our perceived throughput, I don't mind us actually having better performance than reported :).