### PR TITLE
Switch kronos docker from ubuntu 14.04 to phusion/baseimage as base image

### DIFF
--- a/kronos/docker/Dockerfile
+++ b/kronos/docker/Dockerfile
@@ -1,5 +1,7 @@
 # https://docs.docker.com/articles/dockerfile_best-practices/
-FROM ubuntu:14.04
+# Check for updates:
+#   https://github.com/phusion/baseimage-docker/blob/master/Changelog.md
+FROM phusion/baseimage:0.9.16
 
 # Install dependencies.
 RUN \
@@ -11,7 +13,6 @@ RUN \
   python-all-dev \
   python-pip \
   python2.7 \
-  supervisor \
   uuid-dev \
   wget
 
@@ -24,5 +25,6 @@ WORKDIR /chronology/kronos
 RUN python setup.py install
 RUN mkdir -p /home/kronos && chown -R kronos:kronos /home/kronos
 
-COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-CMD ["/usr/bin/supervisord"]
+RUN mkdir /etc/service/kronos
+COPY kronos.sh /etc/service/kronos/run
+CMD ["/sbin/my_init"]

--- a/kronos/docker/kronos.sh
+++ b/kronos/docker/kronos.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+LOGDIR=/var/log/kronos
+LOGFILE=$LOGDIR/uwsgi.log
+LIBDIR=/usr/lib/kronos
+
+(cd $LIBDIR/uwsgi && ./uwsgi --ini /etc/uwsgi/kronos.ini --logto $LOGFILE)

--- a/kronos/docker/supervisord.conf
+++ b/kronos/docker/supervisord.conf
@@ -1,5 +1,0 @@
-[supervisord]
-nodaemon=true
-
-[program:kronos]
-command=sudo service kronosd start


### PR DESCRIPTION
Switch base image because of these benefits: http://phusion.github.io/baseimage-docker/#intro

- Added kronos.sh, which is the script the phusion baseimage init system runs. It can't be a daemon.
- Removed supervisord because we no longer need it.
- We also don't need the kronos init.d script in the docker image, but I kept the `install_kronosd.py` script the same because it might be used for non-docker installs.