### PR TITLE
Create Dockerfile for installing storage backends for running kronos unit tests.

### DIFF
--- a/kronos/setup.py
+++ b/kronos/setup.py
@@ -15,14 +15,14 @@ REQUIREMENTS = [
                                              'requirements.txt')).readlines()
   if not line.startswith('git+')
 ]
-DEPDENDENCY_LINKS = [
+DEPENDENCY_LINKS = [
   line.strip() for line in open(os.path.join(os.path.dirname(__file__),
                                              'requirements.txt')).readlines()
   if line.startswith('git+')
 ]
 
 # Add dependency_links to requires:
-for link in DEPDENDENCY_LINKS:
+for link in DEPENDENCY_LINKS:
   module, version = link.split('=')[1].rsplit('-', 1)
   REQUIREMENTS.append('%s==%s' % (module, version))
 
@@ -48,7 +48,7 @@ setup(name='kronos',
       url='https://github.com/Locu/chronology/kronos',
       keywords=['kronos', 'analytics', 'metrics', 'client', 'logging'],
       install_requires=REQUIREMENTS,
-      dependency_links=DEPDENDENCY_LINKS,
+      dependency_links=DEPENDENCY_LINKS,
       author='GoDaddy',
       author_email='devs@locu.com',
       cmdclass={

--- a/kronos/tests/Dockerfile
+++ b/kronos/tests/Dockerfile
@@ -1,0 +1,52 @@
+# Dockerfile for running kronos tests with various backends.
+
+# https://docs.docker.com/articles/dockerfile_best-practices/
+# Check for updates:
+#   https://github.com/phusion/baseimage-docker/blob/master/Changelog.md
+FROM phusion/baseimage:0.9.16
+
+# Install dependencies.
+RUN \
+  apt-get update && \
+  apt-get install -y \
+  build-essential \
+  libevent-dev \
+  libpcre3-dev \
+  python-all-dev \
+  python-pip \
+  python2.7 \
+  supervisor \
+  uuid-dev \
+  wget
+
+# Set up Cassandra, Elasticsearch.
+RUN echo "deb http://debian.datastax.com/community stable main" | \
+  sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
+RUN curl -L http://debian.datastax.com/debian/repo_key | sudo apt-key add -
+RUN echo "deb http://packages.elasticsearch.org/elasticsearch/1.5/debian \
+  stable main" | \
+  sudo tee -a /etc/apt/sources.list
+RUN wget -qO - https://packages.elasticsearch.org/GPG-KEY-elasticsearch | \
+  sudo apt-key add -
+
+RUN apt-get update && \
+  apt-get install -y \
+  openjdk-7-jre \
+  dsc20=2.0.11-1 \
+  cassandra=2.0.11 \
+  elasticsearch
+RUN service cassandra stop
+
+COPY chronology/kronos/requirements.txt /requirements.txt
+RUN sudo pip install -r /requirements.txt
+
+COPY chronology /chronology
+WORKDIR /chronology/kronos
+
+RUN python setup.py install
+RUN mkdir -p /home/kronos && chown -R kronos:kronos /home/kronos
+
+COPY run-cassandra.sh /etc/my_init.d/cassandra.sh
+COPY run-elasticsearch.sh /etc/my_init.d/elasticsearch.sh
+
+CMD ["/sbin/my_init", "--quiet", "--", "sh", "-c", "sleep 15; ./runtests.py all"]

--- a/kronos/tests/README.md
+++ b/kronos/tests/README.md
@@ -1,0 +1,10 @@
+Running Tests
+-------------
+Unit tests for Kronos can be run by building and running a test docker image
+with all the storage dependencies installed.
+
+.. code:: sh
+    ./build.sh {GIT_HASH} {DOCKER_IMAGE_NAME}
+    docker run {DOCKER_IMAGE_NAME}
+
+The test results will be printed to stdout.

--- a/kronos/tests/build.sh
+++ b/kronos/tests/build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+python ../../docker_tools/manage_docker.py export --hash $1 --export-path $(git rev-parse --show-toplevel)/kronos/tests/chronology --repository-path $(git rev-parse --show-toplevel) && \
+python ../../docker_tools/manage_docker.py build --dockerfile-directory . --tag $2

--- a/kronos/tests/run-cassandra.sh
+++ b/kronos/tests/run-cassandra.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+service cassandra start

--- a/kronos/tests/run-elasticsearch.sh
+++ b/kronos/tests/run-elasticsearch.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+service elasticsearch start


### PR DESCRIPTION
@silasbw I'm not sure about how to choose between creating runit entries in Phusion and just adding scripts to `/etc/my_init.d`. I went with the later because running cassandra in the foreground causes logs to go to stdout, which was overwhelming.