### PR TITLE
Switch the order of int, float cast

### DIFF
--- a/metis/metis/core/execute/utils.py
+++ b/metis/metis/core/execute/utils.py
@@ -203,10 +203,8 @@ def get_properties_accessed_by_value(value):
   return properties
 
 
-def cast_to_number(value, default=None):
-  for cast in (int, float):
-    try:
-      return cast(value)
-    except (TypeError, ValueError):
-      pass
-  return default
+def safe_float(value, default=None):
+  try:
+    return float(value)
+  except (TypeError, ValueError):
+    return default


### PR DESCRIPTION
When calling an avg aggregate on a field that contains floats they are currently cast to int first (which succeeds) and the result is incorrect. Switching the order fixes the problem, but it seems like this doesn't do anything. Both casts seem like they will always succeed. Maybe it was intended that strings would come in here? This might actually be a Jia issue, as I believe Jia attempts to cast strings to numbers before sending to Metis...

Thoughts about this? Should clients (including Jia) be required to send strings for all constants? Alternatively, we could cast to string as the first step in this `cast_to_number` function for the same effect.