### PR TITLE
Include non-required fields in jia property autocomplete

### DIFF
--- a/jia/jia/static/app/board/board.js
+++ b/jia/jia/static/app/board/board.js
@@ -166,7 +166,7 @@ function ($scope, $http, $location, $timeout, $injector, $routeParams,
   $scope.updateSchema = function (panel) {
     $http.get('/streams/' + panel.data_source.query.stream)
       .success(function (data, status, headers, config) {
-        panel.cache.streamProperties = data.required;
+        panel.cache.streamProperties = Object.keys(data.properties);
       }
     );
   }


### PR DESCRIPTION
Currently only required fields are shown in the property autocomplete box in the query builder, which is a bug.